### PR TITLE
sbf: fix overrun on invalid length

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ This repository contains user-space gps drivers, used as a submodule in
 All platform-specific stuff is done via a callback function and a
 `definitions.h` header file.
 
+In order for the project to build, `definitions.h` must include definitions for `sensor_gnss_relative_s`, `sensor_gps_s` and `satellite_info_s`.
+For example, check the implementation in [PX4 Autopilot](https://github.com/PX4/PX4-Autopilot/blob/master/src/drivers/gps/definitions.h) or [QGroundControl](https://github.com/mavlink/qgroundcontrol/blob/master/src/GPS/definitions.h). 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -462,7 +462,9 @@ int GPSDriverSBF::payloadRxDone()
 	struct tm timeinfo;
 	time_t epoch;
 
-	if (_buf.length <= 4 || _buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
+	if (_buf.length <= 4 ||
+		_buf.length > _rx_payload_index ||
+		_buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
 		return 0;
 	}
 


### PR DESCRIPTION
Before checking the CRC across header and payload, we need to check if the length is valid. If the length is longer than what we have read into the buffer, it must be invalid and we don't have to bother with the CRC.

This should fix a potential segfault where the CRC overruns the allocated buffer due to a corrupt length field.